### PR TITLE
Create /var/lib/monit on RHEL family systems for idfile.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,16 @@ class monit (
     require => Package[$monit::params::monit_package],
   }
 
+  if $::osfamily == 'redhat' {
+    file { '/var/lib/monit':
+	    ensure  => directory,
+	    owner   => 'root',
+	    group   => 'root',
+	    mode    => '0755',
+	    before  => Service[$monit::params::monit_service]
+	  }
+  }
+
   service { $monit::params::monit_service:
     ensure     => $service_state,
     enable     => $run_service,


### PR DESCRIPTION
Fixes following error reported by hosts using role_procserver:

Starting monit: monit: Error opening the idfile '/var/lib/monit/id' -- No such file or directory
