### PR TITLE
allow configurable port for monit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class monit (
   $delay      = $interval * 2,
   $logfile    = $monit::params::logfile,
   $mailserver = 'localhost', 
+  $httpd_port = 2812,
 ) inherits monit::params {
 
   $conf_include = "${monit::params::conf_dir}/*"
@@ -49,7 +50,7 @@ class monit (
     ensure => $ensure,
   }
 
-  # Template uses: $admin, $conf_include, $interval, $logfile
+  # Template uses: $admin, $conf_include, $interval, $logfile, $httpd_port
   file { $monit::params::conf_file:
     ensure  => $ensure,
     content => template('monit/monitrc.erb'),

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -111,7 +111,7 @@ set alert <%= @admin %>                       # receive all alerts
 ## services monitored and manage services from a web interface. See the
 ## Monit Wiki if you want to enable SSL for the web server. 
 #
-set httpd port 2812 and
+set httpd port <%= httpd_port %> and
     use address localhost  # only accept connection from localhost
     allow localhost        # allow localhost to connect to the server and
 #     allow admin:monit      # require user 'admin' with password 'monit'


### PR DESCRIPTION
@kenbreeman @pranav Right now the port monit runs on conflicts with some ports mesos is allocating from, it'd be nice to be able to customize the port we run monit on