### PR TITLE
Adding alerting config capabilities

### DIFF
--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -38,6 +38,9 @@ define monit::monitor (
   $start_timeout = undef,
   $stop_timeout  = undef,
   $group         = $name,
+  $alert_email   = undef,
+  $alert_events  = '',
+  $email_format  = undef,
 ) {
   include monit::params
 

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -1,4 +1,10 @@
 check process <%= @name %> with pidfile <%= @pidfile %>
+<% if @alert_email -%>
+  alert <%= @alert_email %> <%= @alert_events %> <% if @email_format -%> mail-format {
+<%= @email_format %>
+}
+<% end -%>
+<% end -%>
   start program = "<%= @start_script %>"
 <% if @start_timeout -%>
     with timeout <%= @start_timeout %> seconds


### PR DESCRIPTION
Some of our monit configs send our team emails letting us know when services fail (i.e. the HBase HMaster). This change introduces some parameters to the `monit::monitor` class and relevant template that would make this configuration possible. 