### PR TITLE
Adding support for SSL/TLS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class monit (
   $monit_user      = undef,
   $monit_password  = undef,
   $package_version = undef,
+  $use_ssl         = undef,
+  $ssl_cert_path   = undef,
 ) inherits monit::params {
 
   $conf_include = "${monit::params::conf_dir}/*"

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -111,7 +111,17 @@ set alert <%= @admin %>                       # receive all alerts
 ## services monitored and manage services from a web interface. See the
 ## Monit Wiki if you want to enable SSL for the web server. 
 #
-set httpd port <%= @httpd_port %> and
+<% if @use_ssl -%>
+set tls options {
+    verify: enable
+    # Self signed certificats are rejected by default
+    selfsigned: allow
+}
+<% end -%>
+set httpd port <%= @httpd_port %><% if @use_ssl %>
+    with tls {
+        pemfile: <%= @ssl_cert_path %>
+    }<% end %> and
 <% if @allow_remote -%>
     allow <%= @monit_user %>:<%= @monit_password %>
 <% else -%>


### PR DESCRIPTION
Enable Monit to be configured to run with SSL and only accept HTTPS connections
